### PR TITLE
checkToken updated to check username as well

### DIFF
--- a/Server/util/middleware.js
+++ b/Server/util/middleware.js
@@ -20,7 +20,7 @@ let checkToken = (req, res, next) => {
           message: "Token is not valid",
         });
       } else {
-        if (decoded.isVerified || decoded.admin) {
+        if ((decoded.isVerified && decoded.username === req.cookies.username) || decoded.admin) {
           req.decoded = decoded;
           next();
         } else {


### PR DESCRIPTION
Changing the **username cookie** to **"ADMIN"** before entering a contest allows users to paste in the IDE and also changing the username cookie to any other roll no gives access to their resume and personal details. 

`cookie.username == "ADMIN" or "ROLL NO"`

The PR fixes the issue by changing the checkToken middleware function to also validate the username cookie with jwt decoded username.

Thank you.