### PR TITLE
fixed auto date override to null string

### DIFF
--- a/Client/views/contestupdate.ejs
+++ b/Client/views/contestupdate.ejs
@@ -26,7 +26,7 @@
 					<p class="comments">Contest Name</p>
 					<textarea name="contestName" rows="5"><%= data.contestName %></textarea>
 					<p class="comments">Contest Date</p>
-					<input name="contestDate" type="date"><%= data.contestDate %></textarea>
+					<input name="contestDate" type="date" value="<%= data.contestDate %>"></textarea>
 					<p class="comments">Contest Duration</p>
 					<textarea name="contestDuration" rows="5"><%= data.contestDuration %></textarea>
 					<p class="comments">Contest Start Time</p>


### PR DESCRIPTION
fixed bug that caused date to auto override to null string in edit contest menu 