### PR TITLE
Add Markdown support in question description

### DIFF
--- a/Client/views/questiondesc.ejs
+++ b/Client/views/questiondesc.ejs
@@ -286,6 +286,35 @@
     display: flex;
     opacity: 0;
   }
+
+  .questiondesc > pre, code, .questionexplain > pre, code  {
+    background-color: rgb(232, 232, 232);
+  }
+
+  .questiondesc > pre {
+    padding: 1em;
+  }
+
+  .questionexplain > pre {
+    padding: 1em;
+    border-radius: 1em;
+  }
+
+  .questiondesc > p {
+    line-height: 2em;
+  }
+
+  .questiondesc > p > code, .inoutformat > p > code {
+    border-radius: 0.35em;
+    padding: 0.25em;
+  }
+
+  img {
+    height: 60%;
+    width: 60%;
+  }
+
+
 </style>
 
 <body oncontextmenu="return false;">
@@ -342,17 +371,17 @@
         <div class="col-md-12 setback">
           <div class="cover">
             <div class="questiondesc">
-              <%= data[0].questionDescriptionText %>
+              <%- data[0].questionDescriptionText %>
             </div>
             <br />
             <div class="questionlabel">Input Format</div>
             <div class="inoutformat">
-              <%= data[0].questionInputText %>
+              <%- data[0].questionInputText %>
             </div>
             <br />
             <div class="questionlabel">Output Format</div>
             <div class="inoutformat">
-              <%= data[0].questionOutputText %>
+              <%- data[0].questionOutputText %>
             </div>
             <br />
             <div class="questionlabel">Sample Input</div>
@@ -374,7 +403,7 @@
             </div>
             <div class="questionexplain">
               <%_ %>
-                <%= data[0].questionExplanation %>
+                <%- data[0].questionExplanation %>
             </div>
             <br />
             <br />

--- a/Server/controllers/question.controller.js
+++ b/Server/controllers/question.controller.js
@@ -4,6 +4,8 @@ const xlsx = require("xlsx");
 const contests = require("./contest.controller.js");
 const participations = require("./participation.controller.js");
 const Contest = require("../models/contest.model.js");
+const { marked } = require('marked')
+
 // const Base64 = require('js-base64').Base64;
 // Create and Save a new question
 exports.create = (req, res) => {
@@ -45,9 +47,9 @@ exports.create = (req, res) => {
             questionId: req.body.questionId,
             questionName: req.body.questionName,
             contestId: req.body.contestId,
-            questionDescriptionText: req.body.questionDescriptionText,
-            questionInputText: req.body.questionInputText,
-            questionOutputText: req.body.questionOutputText,
+            questionDescriptionText: marked.parse(req.body.questionDescriptionText),
+            questionInputText: marked.parse(req.body.questionInputText),
+            questionOutputText: marked.parse(req.body.questionOutputText),
             questionExampleInput1: req.body.questionExampleInput1,
             questionExampleOutput1: req.body.questionExampleOutput1,
             questionExampleInput2: req.body.questionExampleInput2,
@@ -60,13 +62,13 @@ exports.create = (req, res) => {
             questionHiddenOutput1: req.body.questionHiddenOutput1,
             questionHiddenOutput2: req.body.questionHiddenOutput2,
             questionHiddenOutput3: req.body.questionHiddenOutput3,
-            questionExplanation: req.body.questionExplanation,
+            questionExplanation: marked.parse(req.body.questionExplanation),
             code_py: req.body.code_py,
             code_java: req.body.code_java,
             code_c: req.body.code_c,
             code_cpp: req.body.code_cpp,
             author: req.body.author,
-            editorial: req.body.editorial,
+            editorial: marked.parse(req.body.editorial),
             difficulty: req.body.difficulty,
             estimateTime: req.body.estimateTime,
             language: req.body.language,

--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -25,6 +25,7 @@
         "js-base64": "^2.5.1",
         "jsdom": "^16.7.0",
         "jsonwebtoken": "^9.0.0",
+        "marked": "^12.0.1",
         "moment": "^2.24.0",
         "moment-timezone": "^0.5.28",
         "mongoose": "^6.8.2",
@@ -3573,6 +3574,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/marked": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.1.tgz",
+      "integrity": "sha512-Y1/V2yafOcOdWQCX0XpAKXzDakPOpn6U0YLxTJs3cww6VxOzZV1BTOOYWLvH3gX38cq+iLwljHHTnMtlDfg01Q==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/media-typer": {
@@ -8050,6 +8062,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "marked": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.1.tgz",
+      "integrity": "sha512-Y1/V2yafOcOdWQCX0XpAKXzDakPOpn6U0YLxTJs3cww6VxOzZV1BTOOYWLvH3gX38cq+iLwljHHTnMtlDfg01Q=="
     },
     "media-typer": {
       "version": "0.3.0",

--- a/Server/package.json
+++ b/Server/package.json
@@ -26,6 +26,7 @@
     "js-base64": "^2.5.1",
     "jsdom": "^16.7.0",
     "jsonwebtoken": "^9.0.0",
+    "marked": "^12.0.1",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.28",
     "mongoose": "^6.8.2",

--- a/Server/yarn.lock
+++ b/Server/yarn.lock
@@ -2328,6 +2328,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+marked@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.npmjs.org/marked/-/marked-12.0.1.tgz"
+  integrity sha512-Y1/V2yafOcOdWQCX0XpAKXzDakPOpn6U0YLxTJs3cww6VxOzZV1BTOOYWLvH3gX38cq+iLwljHHTnMtlDfg01Q==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"


### PR DESCRIPTION
This pr adds markdown functionality to question description pages.

page can now display 
- links
- images
- headings
- code blocks
- lists
- horizontal seperators within a section
- bold, italic, bold-italic text

(note: caveat with image is it should be hosted somewhere)

below is a sample rendition of functionality
![image](https://github.com/BuildIT-IARE/BuildIT/assets/68043860/8be7acba-c8b4-49c2-a926-5c057bd38291)
